### PR TITLE
Store keywords as single string for better querying

### DIFF
--- a/src/redux/actions/item.actions.test.ts
+++ b/src/redux/actions/item.actions.test.ts
@@ -4,7 +4,7 @@ const mockRawItem = {
   body:
     '&lt;ul&gt;\n&lt;li&gt;Place item in the &lt;strong&gt;Garbage Bin.&lt;/strong&gt;&lt;/li&gt;\n&lt;/ul&gt;',
   category: 'Garbage',
-  keywords: 'Bread bag tag, Milk bag tag, elastic band',
+  keywords: ' Bread bag tag, Milk bag tag, elastic band, ',
   title: 'Garbage (wrapping and tying)'
 }
 
@@ -13,7 +13,7 @@ test('transform raw item', () => {
   const expectedResult = {
     body: `<ul>\n<li>Place item in the <strong>Garbage Bin.</strong></li>\n</ul>`,
     category: 'Garbage',
-    keywords: new Set(['bread bag tag', 'milk bag tag', 'elastic band']),
+    keywords: 'bread bag tag, milk bag tag, elastic band',
     title: 'Garbage (wrapping and tying)',
     favourited: false,
     id: 0

--- a/src/redux/actions/item.actions.ts
+++ b/src/redux/actions/item.actions.ts
@@ -9,17 +9,14 @@ function transformRawItem(item, index) {
   const decodedBody = he.decode(body)
 
   // Split keywords by comma and remove any leading or trailing whitespace
-  const keywordsArray = keywords.split(',').map((keyword) => {
-    return keyword.trim().toLowerCase()
-  })
-  const keywordsSet = new Set(keywordsArray)
+  const cleanedKeywords = keywords.trim().toLowerCase()
 
   return {
     id: index,
     title,
     category,
     body: decodedBody,
-    keywords: keywordsSet,
+    keywords: cleanedKeywords,
     favourited: false
   }
 }

--- a/src/redux/actions/item.actions.ts
+++ b/src/redux/actions/item.actions.ts
@@ -8,8 +8,10 @@ function transformRawItem(item, index) {
   // Body comes in as encoded HTML, we must decode it to properly render
   const decodedBody = he.decode(body)
 
-  // Split keywords by comma and remove any leading or trailing whitespace
-  const cleanedKeywords = keywords.trim().toLowerCase()
+  const cleanedKeywords = keywords
+    .trim() // Remove leading or trailing whitespace
+    .replace(/,$/, '') // Remove trailing commas
+    .toLowerCase()
 
   return {
     id: index,

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -3,6 +3,6 @@ export interface Item {
   body: string
   category: string
   title: string
-  keywords: Set<string>
+  keywords: string
   favourited: boolean
 }

--- a/src/utilities/item.utils.test.ts
+++ b/src/utilities/item.utils.test.ts
@@ -7,7 +7,7 @@ const mockItems = [
     category: 'Garbage',
     favourited: false,
     id: 0,
-    keywords: new Set(['plastic', 'trash', 'garbage', 'common']),
+    keywords: 'plastic, trash, garbage, common',
     title: 'Garbage (wrapping and tying)'
   },
   {
@@ -16,7 +16,7 @@ const mockItems = [
     category: 'Compost',
     favourited: true,
     id: 52,
-    keywords: new Set(['food', 'compost', 'green', 'common']),
+    keywords: 'food, compost, green, common',
     title: 'Banana Peel'
   }
 ]

--- a/src/utilities/item.utils.ts
+++ b/src/utilities/item.utils.ts
@@ -13,7 +13,7 @@ function getFavourites(items: Array<Item>) {
 function getResultIndices(items: Array<Item>, query: string) {
   let matchedIndices = [] as Array<number>
   for (let i = 0; i < items.length; i++) {
-    if (items[i].keywords.has(query.toLowerCase())) {
+    if (items[i].keywords.includes(query.toLowerCase())) {
       matchedIndices.push(i)
     }
   }


### PR DESCRIPTION
Keywords will be stored as a string instead of a set in order to check if the query is a substring